### PR TITLE
Properly track dependencies for autofile directive

### DIFF
--- a/sphinxjulia/juliaautodoc.py
+++ b/sphinxjulia/juliaautodoc.py
@@ -61,6 +61,9 @@ class AutoDirective(Directive):
             query.walk_tree(node, self.register, scope)
             # Add docstrings
             query.walk_tree(node, self.docstring, scope)
+
+        self.state.document.settings.record_dependencies.add(self.sourcepath)
+
         return self.matches
 
     def filter(self, modulenode):


### PR DESCRIPTION
This way, the documentation will actually be rebuilt when re-running
Sphinx after having changed a source file.