### PR TITLE
Switch setup.py setuptools

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -53,6 +53,11 @@ or alternatively adding the path directly in the sphinx config file :file:`conf.
     import os
     sys.path.insert(0, os.path.abspath('~/sphinx-julia'))
 
+or installing the repository in development mode
+
+.. code-blcok:: bash
+
+    >> python setup.py develop
 
 Usage
 -----

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='Sphinx-Julia',
       version='0.2',


### PR DESCRIPTION
This more modern setup script style includes the ability to perform a
development install using `python setup.py develop`.