### PR TITLE
Show full function signatures in documentation.

### DIFF
--- a/sphinxjulia/modelparser.py
+++ b/sphinxjulia/modelparser.py
@@ -185,6 +185,8 @@ def parse_signaturestring(text):
             i = i_closing
         elif x == ";":
             argtype = "keywordarguments"
+            _appendargument(d, text[i_start:i].strip(), argtype)
+            i_start = i+1
         elif x == ",":
             _appendargument(d, text[i_start:i].strip(), argtype)
             i_start = i+1

--- a/sphinxjulia/translators_html.py
+++ b/sphinxjulia/translators_html.py
@@ -10,7 +10,12 @@ def format_signature(signature):
 
 
 def format_argument(argument):
-    return "<em>" + argument.name + "</em>"
+    out = "<em>" + argument.name + "</em>"
+    if argument.argumenttype:
+        out += "::" + argument.argumenttype
+    if argument.value:
+        out += " = <tt>" + argument.value + "</tt>"
+    return out
 
 
 def format_templateparameters(args):

--- a/sphinxjulia/translators_latex.py
+++ b/sphinxjulia/translators_latex.py
@@ -10,7 +10,12 @@ def format_signature(translator, signature):
 
 
 def format_argument(translator, argument):
-    return r"\emph{%s}" % translator.encode(argument.name)
+    out = r"\emph{%s}" % translator.encode(argument.name)
+    if argument.argumenttype:
+        out += "::" + translator.encode(argument.argumenttype)
+    if argument.value:
+        out += r" = \texttt{%s}" % translator.encode(argument.value)
+    return out
 
 
 def format_templateparameters(translator, args):


### PR DESCRIPTION
Now the domain:

    .. jl:function:: f(a::Vector{Int}, b=123)

        Some example...

Will be rendered into:
> *function* **`f`**(*a*::Vector{Int}, *b*=`123`)
>
> Some example...

Rather than the less descriptive

> *function* **`f`**(*a*, *b*)
>
> Some example...