### PR TITLE
Fix juliaautodoc

### DIFF
--- a/sphinxjulia/juliaautodoc.py
+++ b/sphinxjulia/juliaautodoc.py
@@ -6,6 +6,7 @@ from docutils.statemachine import ViewList
 from sphinx.util.docfields import Field, GroupedField, TypedField
 from sphinx.util.docfields import DocFieldTransformer
 from sphinx.locale import l_
+from sphinx.errors import SphinxError
 
 from . import model, modelparser, query
 
@@ -129,6 +130,14 @@ def setup(app):
     app.add_directive('jl:autotype', AutoType)
     app.add_directive('jl:autoabstract', AutoAbstract)
 
-    # Events
-    app.add_event('autodoc-process-docstring')
-    app.add_event('autodoc-skip-member')
+    # Events (NB these may already have been added by the regular Sphinx
+    # autodoc extension)
+    try:
+        app.add_event('autodoc-process-docstring')
+    except SphinxError:
+        pass
+    
+    try:
+        app.add_event('autodoc-skip-member')
+    except SphinxError:
+        pass

--- a/sphinxjulia/modelparser.py
+++ b/sphinxjulia/modelparser.py
@@ -69,7 +69,7 @@ class JuliaParser:
         p = subprocess.Popen(["julia", scriptpath, sourcepath],
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (buf, err) = p.communicate()
-        if err:
+        if p.returncode != 0:
             print("Parsing file {} failed with error message:".format(sourcepath))
             print("-"*80)
             print(err.decode("utf-8"))


### PR DESCRIPTION
Fixes a couple of issues which prevented this feature working:

* Ignore warnings from Julia on stderr: only fail if Julia actually crashes. This prevents deprecation warnings and such resulting in failing builds.

* Allow autodoc and juliaautodoc to peacefully coexist.