### PR TITLE
Fix Python writer string literal escaping.

### DIFF
--- a/sphinxjulia/parsetools/src/writer_python.jl
+++ b/sphinxjulia/parsetools/src/writer_python.jl
@@ -7,9 +7,9 @@ function Base.string(m::model.JuliaModel)
     for name in fieldnames(m)
         p = getfield(m, name)
         if typeof(p) <: AbstractString
-            p = "'$p'"
+            p = repr(p)
         elseif typeof(p) <: Array{AbstractString, 1}
-            p = "["*join(["'$x'" for x=p], ", ")*"]"
+            p = "["*join([repr(x) for x=p], ", ")*"]"
         elseif typeof(p) <: Array
             p = "["*join([string(x) for x=p], ", ")*"]"
         elseif p == nothing


### PR DESCRIPTION
This change uses repr() to output a string in which quotes and newlines are
correctly quoted. Though repr() makes Julia-compatible string literals, these
literals are also compatible with Python.

An example where this caused problems is if a file being documented contained a
function with a multi-line function as a default function argument.