### PR TITLE
Workaround parsing of constructor docstrings in Julia's AST

### DIFF
--- a/sphinxjulia/parsetools/src/reader_file.jl
+++ b/sphinxjulia/parsetools/src/reader_file.jl
@@ -252,6 +252,15 @@ function read_type(x::Expr, docstring::AbstractString)
     @assert x.args[3].head == :block
     for arg in x.args[3].args
         innerdocstring, arg = extractdocstring(arg)
+        # XXX: Julia's AST parser (as of v0.6) does not correctly parse
+        # docstrings associated with type constructors. In practice, Julia's
+        # 'help' tool will show type-level documentation when trying to lookup
+        # a constructor. The work-around below does essentially the same thing
+        # in the documentation by copying the type's docstring into the
+        # constructor.
+        if isempty(innerdocstring)
+            innerdocstring = docstring
+        end
         if typeof(arg) != Expr
             continue
         elseif isfield(arg)


### PR DESCRIPTION
Julia's AST parser (as of v0.6) does not correctly parse docstrings associated
with type constructors. Unlike other functions, docstrings do not get combined
into a AST along with the function implementation and instead the string ends
up seperate as just a lone string literal.

In practice, Julia's 'help' tool will show type-level documentation when trying
to lookup a constructor. The work-around in this commit does essentially the
same thing when a constructor function is autofunction'd by substituting the
type's docstring.