### PR TITLE
Add Julia 0.6-style type-parameter syntax.

### DIFF
--- a/sphinxjulia/modelparser.py
+++ b/sphinxjulia/modelparser.py
@@ -209,7 +209,7 @@ def parse_functionstring(text):
     i_parentheses = f(text, "(")
     i_returntype = f(text, "->")
 
-    # Test for template parameters
+    # Test for template parameters-at-start
     if i_braces < i_parentheses and i_braces < i_returntype:
         i_close = find_closing_bracket(text, i_braces, "{")
         assert i_close != -1
@@ -231,6 +231,17 @@ def parse_functionstring(text):
     if i_returntype < len(text):
         d["returntype"] = text[i_returntype + 2:]
         text = text[:i_returntype]
+    
+    # Test for template parameters-at-end
+    i_where = f(text, " where")
+    if i_where < len(text):
+        assert "templateparameters" not in d
+        i_braces = f(text, "{")
+        i_close = find_closing_bracket(text, i_braces, "{")
+        assert i_braces < i_close and i_close < len(text)
+        templateparameters = text[i_braces+1:i_close].split(",")
+        d["templateparameters"] = [t.strip() for t in templateparameters]
+        text = text[:i_where]
 
     # Text only contains the function name at this point
     if "." in text:

--- a/sphinxjulia/parsetools/src/reader_file.jl
+++ b/sphinxjulia/parsetools/src/reader_file.jl
@@ -164,9 +164,13 @@ function read_function(x::Expr, docstring::AbstractString)
         signature = read_signature([])
         return model.Function(name, modulename, templateparameters, signature, docstring)
     end
+    templateparameters = AbstractString[]
     if x.args[1].head == :(::) # function ...f(...)::Type
         funcexpr = x.args[1].args[1]
         returntype = x.args[1].args[2] # Ignore returntype for now # TODO!
+    elseif x.args[1].head == :where # function ...f(...) where {T}
+        funcexpr = x.args[1].args[1]
+        templateparameters = [string(x) for x=x.args[1].args[2:end]]
     else
         funcexpr = x.args[1]
     end
@@ -174,7 +178,6 @@ function read_function(x::Expr, docstring::AbstractString)
     if typeof(definition) == Symbol # function f(...)
         name = string(definition)
         modulename = ""
-        templateparameters = AbstractString[]
     else
         @assert typeof(definition) == Expr
         if definition.head == :curly # function Base.f{T}(...)
@@ -182,7 +185,6 @@ function read_function(x::Expr, docstring::AbstractString)
             templateparameters = [string(x) for x=definition.args[2:end]]
         else # function Base.f(...)
             fullname = definition
-            templateparameters = AbstractString[]
         end
         if typeof(fullname) == Symbol # function f(...)
             modulename = ""

--- a/sphinxjulia/translators_html.py
+++ b/sphinxjulia/translators_html.py
@@ -72,11 +72,13 @@ def visit_function(translator, node):
     I('<dt id="%s">' % node["ids"][0])
     I('<em class="property">function </em>')
     I('<code class="descname">')
-    I(node.name + tpars)
+    I(node.name)
     I('</code>')
     I('<span class="sig-paren">(</span>')
     I(signature)
     I('<span class="sig-paren">)</span>')
+    if tpars:
+        I(" where " + tpars)
     translator.add_permalink_ref(node, "Permalink to this function")
     I("</dt><dd>")
 

--- a/sphinxjulia/translators_latex.py
+++ b/sphinxjulia/translators_latex.py
@@ -62,14 +62,16 @@ def visit_abstract(translator, node):
 
 
 def visit_function(translator, node):
-    tpars = format_templateparameters(translator, node.templateparameters)
-    name = (r'\textbf{\texttt{%s}}' % translator.encode(node.name)) + tpars
+    name = (r'\textbf{\texttt{%s}}' % translator.encode(node.name))
     signature = format_signature(translator, node.signature)
+    tpars = format_templateparameters(translator, node.templateparameters)
+    if tpars:
+        tpars = translator.encode(" where " + tpars)
     I = translator.body.append
     I('\n\\begin{fulllineitems}\n')
     I(r'\phantomsection')
     I(r'\label{index:%s}' % node["ids"][0])
-    I('\\pysiglinewithargsret{\\textbf{function} %s}{%s}{}\n' % (name, signature))
+    I('\\pysiglinewithargsret{\\textbf{function} %s}{%s}{%s}\n' % (name, signature, tpars))
 
     # I('<dl class="function">')
     # I('<dt id="%s">' % node["ids"][0])


### PR DESCRIPTION
In Julia versions prior to 0.6, function type parameters looked something like
this:

    function f{T}(x::T)
        ...
    end

As for Julia 0.6, this syntax has been deprecated and a new 'where' syntax is
preferred:

    function f(x::T) where {T}
        ...
    end

This commit adds support for parsing the new syntax both in the Julia and
Python side parsers. It also changes the rendering of function prototypes to
use the new-style syntax.