### PR TITLE
Match on varargs

### DIFF
--- a/sphinxjulia/modelparser.py
+++ b/sphinxjulia/modelparser.py
@@ -184,8 +184,8 @@ def parse_signaturestring(text):
                                  "".format(x, i, repr(text)))
             i = i_closing
         elif x == ";":
-            argtype = "keywordarguments"
             _appendargument(d, text[i_start:i].strip(), argtype)
+            argtype = "keywordarguments"
             i_start = i+1
         elif x == ",":
             _appendargument(d, text[i_start:i].strip(), argtype)

--- a/sphinxjulia/query.py
+++ b/sphinxjulia/query.py
@@ -32,17 +32,26 @@ def match_signature(pattern, signature):
     if len(parguments) == len(pattern.keywordarguments) == 0 and\
        pattern.varargs is None and pattern.kwvarargs is None:
         return True
+    
     farguments = signature.positionalarguments + signature.optionalarguments
     if len(parguments) != len(farguments):
         return False
     for i in range(len(parguments)):
         if not match_argument(parguments[i], farguments[i]):
             return False
+    if pattern.varargs and signature.varargs and \
+            not match_argument(pattern.varargs, signature.varargs):
+        return False
+    
     pkwd = {arg.name: arg for arg in pattern.keywordarguments}
     fkwd = {arg.name: arg for arg in signature.keywordarguments}
     for name in pkwd:
         if name not in fkwd or not match_argument(fkwd[name], pkwd[name]):
             return False
+    if pattern.kwvarargs and signature.kwvarargs and \
+            not match_argument(pattern.kwvarargs, signature.kwvarargs):
+        return False
+    
     return True
 
 


### PR DESCRIPTION
Previously when matching function signatures, varadic arguments were not compared. Further, there was a bug in the Python-side function signature parsing which mislabelled positional varargs as keyword varargs. This PR fixes both of these issues. 