### PR TITLE
Added Julia 0.7 and 1.0 support

### DIFF
--- a/sphinxjulia/parsetools/scripts/sourcefile2pythonmodel.jl
+++ b/sphinxjulia/parsetools/scripts/sourcefile2pythonmodel.jl
@@ -1,5 +1,9 @@
 include("../src/parsetools.jl")
 
+@static if VERSION < v"0.7.0"
+    stdout = STDOUT
+end
+
 sourcepath = ARGS[1]
 model = parsetools.reader.read_file(sourcepath)
-parsetools.writer.write_python(STDOUT, model)
+parsetools.writer.write_python(stdout, model)

--- a/sphinxjulia/parsetools/src/model.jl
+++ b/sphinxjulia/parsetools/src/model.jl
@@ -1,20 +1,24 @@
-abstract JuliaModel
+@static if VERSION < v"0.7.0"
+  const Nothing = Void
+end
 
-type Argument <: JuliaModel
+abstract type JuliaModel end
+
+mutable struct Argument <: JuliaModel
     name::AbstractString
     argumenttype::AbstractString
     value::AbstractString
 end
 
-type Signature<: JuliaModel
+mutable struct Signature<: JuliaModel
     positionalarguments::Vector{Argument}
     optionalarguments::Vector{Argument}
     keywordarguments::Vector{Argument}
-    varargs::Union{Argument, Void}
-    kwvarargs::Union{Argument, Void}
+    varargs::Union{Argument, Nothing}
+    kwvarargs::Union{Argument, Nothing}
 end
 
-type Function<: JuliaModel
+mutable struct Function<: JuliaModel
     name::AbstractString
     modulename::AbstractString
     templateparameters::Vector{AbstractString}
@@ -22,20 +26,20 @@ type Function<: JuliaModel
     docstring::AbstractString
 end
 
-type Field<: JuliaModel
+mutable struct Field<: JuliaModel
     name::AbstractString
     fieldtype::AbstractString
     value::AbstractString
 end
 
-type Abstract<: JuliaModel
+mutable struct Abstract<: JuliaModel
     name::AbstractString
     templateparameters::Vector{AbstractString}
     parenttype::AbstractString
     docstring::AbstractString
 end
 
-type CompositeType<: JuliaModel
+mutable struct CompositeType<: JuliaModel
     name::AbstractString
     templateparameters::Vector{AbstractString}
     parenttype::AbstractString
@@ -44,7 +48,7 @@ type CompositeType<: JuliaModel
     docstring::AbstractString
 end
 
-type Module<: JuliaModel
+mutable struct Module<: JuliaModel
     name::AbstractString
     body::Vector{Union{Module,Abstract,CompositeType,Function}}
     docstring::AbstractString

--- a/sphinxjulia/parsetools/src/writer_python.jl
+++ b/sphinxjulia/parsetools/src/writer_python.jl
@@ -4,7 +4,7 @@ using ..model
 function Base.string(m::model.JuliaModel)
     typename = last(split(string(typeof(m)), "."))
     d = AbstractString["$(typename)("]
-    for name in fieldnames(m)
+    for name in fieldnames(typeof(m))
         p = getfield(m, name)
         if typeof(p) <: AbstractString
             p = repr(p)


### PR DESCRIPTION
Hey,
sphinx-julia doesn't work with Julia versions past 0.6, so I've made the changes neccessary to get it working with newer versions. I don't know Julia well, so it's possible that there are still some issues, but it worked fine for the documentation of GR.jl.