### PR TITLE
Fix compatibility issue with Sphinx 3

### DIFF
--- a/sphinxjulia/juliaautodoc.py
+++ b/sphinxjulia/juliaautodoc.py
@@ -5,7 +5,10 @@ from docutils.parsers.rst import Directive
 from docutils.statemachine import ViewList
 from sphinx.util.docfields import Field, GroupedField, TypedField
 from sphinx.util.docfields import DocFieldTransformer
-from sphinx.locale import l_
+try:
+    from sphinx.locale import l_
+except ImportError:
+    from sphinx.locale import _ as l_
 from sphinx.errors import SphinxError
 
 from . import model, parsing_juliacode, parsing_sphinxstring, query

--- a/sphinxjulia/juliadomain.py
+++ b/sphinxjulia/juliadomain.py
@@ -2,7 +2,10 @@ from docutils import nodes
 from docutils.parsers.rst import Directive
 
 from sphinx import addnodes
-from sphinx.locale import l_
+try:
+    from sphinx.locale import l_
+except ImportError:
+    from sphinx.locale import _ as l_
 from sphinx.domains import Domain, ObjType
 from sphinx.roles import XRefRole
 from sphinx.util.nodes import make_refnode


### PR DESCRIPTION
Hey @bastikr,
the gettext alias in `sphinx.locale` has been changed in Sphinx 3 and `_` is used as a shortcut for the sphinx-core translator now. This PR tries to import `l_` as before, but if that fails (e.g. because Sphinx 3 is being used) it tries to import `_` which is then used as a drop-in replacement for `l_`.