### PR TITLE
Add support for macro calls in julia function parameters

### DIFF
--- a/sphinxjulia/model.py
+++ b/sphinxjulia/model.py
@@ -73,7 +73,7 @@ class JuliaModelNode(JuliaModel, nodes.Element):
 
 
 class Argument(JuliaModel):
-    __fields__ = {"name":str, "argumenttype": str, "value": str}
+    __fields__ = {"name":str, "argumenttype": str, "value": str, "macrocall": str}
 
     def __str__(self):
         return self.name + "::" + self.argumenttype + "=" + self.value

--- a/sphinxjulia/parsetools/src/model.jl
+++ b/sphinxjulia/parsetools/src/model.jl
@@ -8,6 +8,7 @@ mutable struct Argument <: JuliaModel
     name::AbstractString
     argumenttype::AbstractString
     value::AbstractString
+    macrocall::AbstractString
 end
 
 mutable struct Signature<: JuliaModel

--- a/sphinxjulia/parsetools/src/reader_file.jl
+++ b/sphinxjulia/parsetools/src/reader_file.jl
@@ -69,6 +69,7 @@ end
 function read_argument(arg)
     argumenttype = ""
     value = ""
+    macrocall = ""
     if typeof(arg) == Symbol
         name = arg
     elseif typeof(arg) == Expr
@@ -101,13 +102,25 @@ function read_argument(arg)
                 name = arg.args[1]
                 argumenttype = arg.args[2]
             end
+        elseif arg.head == :macrocall
+            @assert length(arg.args) == 3
+            macrocall = arg.args[1]
+            arg = arg.args[3]
+            if typeof(arg) == Symbol
+                name = arg
+            elseif length(arg.args) == 2
+                name = arg.args[1]
+                value = arg.args[2]
+            else
+                error()
+            end
         else
             error()
         end
     else
         error()
     end
-    model.Argument(string(name), string(argumenttype), string(value))
+    model.Argument(string(name), string(argumenttype), string(value), string(macrocall))
 end
 
 function read_signature(x::Vector)

--- a/sphinxjulia/translators_html.py
+++ b/sphinxjulia/translators_html.py
@@ -15,6 +15,8 @@ def format_signature(signature):
 
 def format_argument(argument):
     out = "<em>" + argument.name + "</em>"
+    if argument.macrocall:
+        out = "<small>" + argument.macrocall + "</small> " + out
     if argument.argumenttype:
         out += "::" + argument.argumenttype
     if argument.value:

--- a/sphinxjulia/translators_latex.py
+++ b/sphinxjulia/translators_latex.py
@@ -15,6 +15,8 @@ def format_signature(translator, signature):
 
 def format_argument(translator, argument):
     out = r"\emph{%s}" % translator.encode(argument.name)
+    if argument.macrocall:
+        out = r"{\scriptsize %s} " % translator.encode(argument.macrocall) + out
     if argument.argumenttype:
         out += "::" + translator.encode(argument.argumenttype)
     if argument.value:


### PR DESCRIPTION
This PR aims to add macro calls in Julia functions. Currently these result in an error [here](https://github.com/bastikr/sphinx-julia/compare/master...danielkaiser:master#diff-c30f0fd1701f1ef9284ae347324cc235a04b3ecfd2b22427e583b97d66759c82L105) and therefore no documentation can be generated.

With this PR the example function
```julia
function test(@nospecialize arg1; @nospecialize arg2::type...=:test)
end
```
looks like this in the resulting HTML documentation
![](https://user-images.githubusercontent.com/9868673/172796389-ea7728d3-c0a2-45fa-aebb-2817f9e485d0.png)

As I am not a Julia developer there I probably missed some special cases, but it should be better than nothing and prevent breaking `sphinx-julia` at least in some situations where macros are used in function argument lists.